### PR TITLE
Update Elixir version and root cert checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/elixir:1.6
+
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - build-{{checksum "mix.lock"}}
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+      - run: mix deps.get
+      - run: mix format --check-formatted
+      - run: mix test
+      - run: mix credo --strict -i todo
+      - run: mix dialyzer --halt-exit-status
+      - save_cache:
+          key: build-{{checksum "mix.lock"}}
+          paths:
+            - deps
+            - _build

--- a/.dialyzerignore
+++ b/.dialyzerignore
@@ -1,0 +1,7 @@
+# erlang public_key functions are unknown because they're defined in a header
+# not included in the PLT by default
+:0: Unknown function public_key:pem_decode/1
+:0: Unknown function public_key:pkix_decode_cert/2
+:0: Unknown function public_key:pkix_path_validation/3
+:0: Unknown function public_key:pkix_verify_hostname/2
+:0: Unknown function public_key:verify/4

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,10 @@
+[
+  inputs: [
+    "test/**/*.{ex,exs}",
+    "lib/**/*.{ex,exs}",
+    "config/**/*.exs",
+    "rel/**/*.exs",
+    "mix.exs"
+  ],
+  line_length: 80,
+]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,7 +3,6 @@
     "test/**/*.{ex,exs}",
     "lib/**/*.{ex,exs}",
     "config/**/*.exs",
-    "rel/**/*.exs",
     "mix.exs"
   ],
   line_length: 80,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
 # AlexaRequestVerifier
 
 ## Description
-Alexa Request Verifier is a library that handles all of the certificate and request verification for Alexa Requests for certified skills. (See the [Alexa Skills Documentation](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/developing-an-alexa-skill-as-a-web-service) for more information)  
+The Pylon Alexa Request Verifier is an updated fork of [an older request verification library](https://github.com/grahac/alexa_request_verifier) that appears to be abandoned. As of June 28, 2018, Amazon switched to using their own certificate authority to sign requests, a change which broke this library. This updated version fixes that issue, along with bringing the library up to Elixir 1.6.
+
+This version also adds a new feature: the ability to verify an incoming request with a single function call instead of using the library's functionality as a `Plug`. To verify requests this way, follow steps 1-3 of the installation instructions below, but instead of installing the request verifier in your request pipeline, call this function using the incoming requests's connection:
+
+```elixir
+AlexaRequestVerifier.verify_request(conn)
+```
+
+If verification fails, `conn.private[:alexa_verify_error]` will contain an error message.
+
+We now join the original project's README, already in progress...
+
+---
+
+... [Alexa Request Verifier] handles all of the certificate and request verification for Alexa Requests for certified skills. See the [Alexa Skills Documentation](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/developing-an-alexa-skill-as-a-web-service) for more information.
 
 Specifically, it will:
 * Confirm the URL for the certificate is a valid Alexa URL
@@ -9,7 +23,7 @@ Specifically, it will:
 * Confirm the request is recent (to avoid playback attacks)
 * Validate the message signature
 
-Alexa Request Verifier uses ConCache to cache certificates once they have been verified.
+Alexa Request Verifier uses ~ConCache~ `:ets` to cache certificates once they have been verified.
 
 
 ## Installation
@@ -19,12 +33,12 @@ by adding `alexa_request_verifier` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:alexa_request_verifier, "~> 0.1.4"}]
+  [{:pylon_alexa_request_verifier, "~> 0.1.5"}]
 end
 ```
 2.You will need to add AlexaRequestVerifier as an application in the same mix.exs file.
 ```elixir
-applications: [..., :alexa_request_verifier] 
+applications: [..., :pylon_alexa_request_verifier]
 ```
 
 3. You will also need to modify your endpoint.ex file by changing the parser as follows:
@@ -44,5 +58,4 @@ end
 A big thanks to the Elixir Forum for helping me navigate all of the semi-documented Erlang :public_key libraries.  [Forum thread](https://elixirforum.com/t/x-509-request-cert-chain-validation-plug-for-alexa-skills/4463/23).
 
 
-The Hex documentation can be found at [https://hexdocs.pm/alexa_request_verifier](https://hexdocs.pm/alexa_request_verifier).
-
+The Hex documentation can be found at [https://hexdocs.pm/pylon_alexa_request_verifier](https://hexdocs.pm/pylon_alexa_request_verifier).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # AlexaRequestVerifier
 
 ## Description
-The Pylon Alexa Request Verifier is an updated fork of [an older request verification library](https://github.com/grahac/alexa_request_verifier) that appears to be abandoned. As of June 28, 2018, Amazon switched to using their own certificate authority to sign requests, a change which broke this library. This updated version fixes that issue, along with bringing the library up to Elixir 1.6.
+The Pylon Alexa Request Verifier is an updated fork of [Charlie Graham's](https://github.com/grahac/alexa_request_verifier) library. As of June 28, 2018, Amazon switched to using their own certificate authority to sign requests, a change which broke this library. This updated version fixes that issue, along with bringing the library up to Elixir 1.6.
 
-This version also adds a new feature: the ability to verify an incoming request with a single function call instead of using the library's functionality as a `Plug`. To verify requests this way, follow steps 1-3 of the installation instructions below, but instead of installing the request verifier in your request pipeline, call this function using the incoming requests's connection:
+This version also adds a new feature: the ability to verify an incoming request with a single function call instead of registering the verifier as part of the request pipeline. To verify requests this way, follow steps 1-3 of the installation instructions below, but instead of performing step 4, call this function using the incoming request's connection:
 
 ```elixir
 AlexaRequestVerifier.verify_request(conn)
@@ -11,7 +11,7 @@ AlexaRequestVerifier.verify_request(conn)
 
 If verification fails, `conn.private[:alexa_verify_error]` will contain an error message.
 
-We now join the original project's README, already in progress...
+We now join the original project's README (plus a couple updates to reflect the new version), already in progress...
 
 ---
 

--- a/lib/alexa_request_verifier/application.ex
+++ b/lib/alexa_request_verifier/application.ex
@@ -8,11 +8,8 @@ defmodule AlexaRequestVerifier.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    # Define workers and child supervisors to be supervised
     children = [
-      # Starts a worker by calling: AlexaRequestVerifier.Worker.start_link(arg1, arg2, arg3)
-      # worker(AlexaRequestVerifier.Worker, [arg1, arg2, arg3]),
-       supervisor(ConCache, [[], [name: :cert_signature_cache]])
+      supervisor(AlexaRequestVerifier.CertCache, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/alexa_request_verifier/cert_cache.ex
+++ b/lib/alexa_request_verifier/cert_cache.ex
@@ -1,0 +1,79 @@
+defmodule AlexaRequestVerifier.CertCache do
+  @moduledoc """
+  This module caches successfully verified Amazon certificates.
+  """
+
+  use GenServer
+
+  require Logger
+
+  @server __MODULE__
+  @table :alexa_request_verifier_certs
+
+  # client
+
+  @doc """
+  Return either the last successfully verified Amazon certificate,
+  or nil if this is the first time the cache has been accessed.
+  """
+  @spec get_cert(cert_url :: String.t()) :: String.t() | nil
+  def get_cert(cert_url) do
+    GenServer.call(@server, {:fetch, cert_url})
+  end
+
+  @doc """
+  Return either the last successfully verified root certificate,
+  or nil if this is the first time the cache has been accessed.
+  """
+  @spec get_last_root() :: String.t() | nil
+  def get_last_root do
+    GenServer.call(@server, {:fetch, "root"})
+  end
+
+  @doc """
+  Store a successfully verified certificate URL in the cache for next time.
+  """
+  @spec store(cert_url :: String.t(), cert_chain :: [String.t()]) :: :ok
+  def store(cert_url, cert_chain) do
+    GenServer.call(@server, {:store, cert_url, cert_chain})
+  end
+
+  @doc """
+  Store a successfully verified root certificate in the cache for next time.
+  """
+  @spec store_root(cert :: String.t()) :: :ok
+  def store_root(cert) do
+    GenServer.call(@server, {:store, "root", cert})
+  end
+
+  # server process
+
+  def start_link do
+    GenServer.start_link(__MODULE__, _args = nil, name: @server)
+  end
+
+  def init(_args) do
+    :ets.new(@table, [:set, :protected, :named_table])
+    {:ok, _state = nil}
+  end
+
+  def handle_call({:fetch, cert_url}, _from, state) do
+    data =
+      case :ets.lookup(@table, cert_url) do
+        [] -> nil
+        [{_url, cert}] -> cert
+      end
+
+    {:reply, data, state}
+  end
+
+  def handle_call({:store, cert_url, cert}, _from, state) do
+    :ets.insert(@table, {cert_url, cert})
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:purge, _from, state) do
+    :ets.delete_all_objects(@table)
+    {:reply, :ok, state}
+  end
+end

--- a/lib/alexa_request_verifier/cert_cache.ex
+++ b/lib/alexa_request_verifier/cert_cache.ex
@@ -18,10 +18,9 @@ defmodule AlexaRequestVerifier.CertCache do
   """
   @spec get_cert(cert_url :: String.t()) :: String.t() | nil
   def get_cert(cert_url) do
-    # check the cache before calling the server
     case :ets.lookup(@table, cert_url) do
       [{_url, cert}] -> cert
-      [] -> GenServer.call(@server, {:fetch, cert_url})
+      [] -> nil
     end
   end
 
@@ -42,16 +41,6 @@ defmodule AlexaRequestVerifier.CertCache do
   def init(_args) do
     :ets.new(@table, [:set, :protected, :named_table])
     {:ok, _state = nil}
-  end
-
-  def handle_call({:fetch, cert_url}, _from, state) do
-    data =
-      case :ets.lookup(@table, cert_url) do
-        [{_url, cert}] -> cert
-        [] -> nil
-      end
-
-    {:reply, data, state}
   end
 
   def handle_call({:store, cert_url, cert}, _from, state) do

--- a/lib/alexa_request_verifier/json_raw_body_parser.ex
+++ b/lib/alexa_request_verifier/json_raw_body_parser.ex
@@ -1,32 +1,33 @@
 defmodule AlexaRequestVerifier.JSONRawBodyParser do
   @moduledoc """
-  Parses json request body if there is a signature header copies the raw body
-
-  Copies raw body to `:raw_body` private assign when `:copy_raw_body` 
-  private assign is true
+  Parses a json request body; if there is a signature header,
+  copies the raw body
   """
 
   @behaviour Plug.Parsers
   alias Plug.Conn
-  require Logger
+
+  def init(options) do
+    options
+  end
 
   def parse(conn, "application", "json", _params, opts) do
- 
-    if Plug.Conn.get_req_header(conn, "signature") != [] do
+    if Conn.get_req_header(conn, "signature") != [] do
       case Conn.read_body(conn, opts) do
         {:ok, body, conn} ->
-            decoder = Keyword.get(opts, :json_decoder) ||
-          raise ArgumentError, "JSON parser expects a :json_decoder option"
-          decoded_body = decoder.decode!(body)      
-            {:ok, decoded_body, Plug.Conn.put_private(conn, :raw_body, body)}
-      
+          decoder =
+            Keyword.get(opts, :json_decoder) ||
+              raise ArgumentError, "JSON parser expects a :json_decoder option"
+
+          decoded_body = decoder.decode!(body)
+          {:ok, decoded_body, Conn.put_private(conn, :raw_body, body)}
+
         {:more, _data, conn} ->
           {:error, :too_large, conn}
       end
     else
       {:next, conn}
     end
-
   end
 
   def parse(conn, _type, _subtype, _headers, _opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,16 +1,18 @@
 defmodule AlexaRequestVerifier.Mixfile do
   use Mix.Project
 
-
   def project do
-    [app: :alexa_request_verifier,
-     version: "0.1.5",
-     elixir: "~> 1.4",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     description: description(),
-     package: package(),
-     deps: deps()]
+    [
+      app: :pylon_alexa_request_verifier,
+      version: "0.1.5",
+      elixir: "~> 1.6",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      description: description(),
+      package: package(),
+      deps: deps(),
+      dialyzer: [ignore_warnings: ".dialyzerignore"]
+    ]
   end
 
   # Configuration for the OTP application
@@ -18,14 +20,17 @@ defmodule AlexaRequestVerifier.Mixfile do
   # Type "mix help compile.app" for more information
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger, :con_cache,
-                    :inets],
-     mod: {AlexaRequestVerifier.Application, []}]
+    [
+      extra_applications: [:logger, :inets],
+      mod: {AlexaRequestVerifier.Application, []}
+    ]
   end
 
- defp description do
+  defp description do
     """
-    Alexa Request Verifier is a library that handles all of the certificate and request verification for Alexa Requests for certified skills. (See the Alexa Skills Documentation for more information).
+    Alexa Request Verifier is a library that handles all of the certificate and
+    request verification for Alexa Requests for certified skills.
+    (See the Alexa Skills Documentation for more information).
     """
   end
 
@@ -40,20 +45,21 @@ defmodule AlexaRequestVerifier.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:phoenix, "~> 1.3"},
-      {:con_cache, "~> 0.12.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:plug, "~> 1.0"},
+      {:certifi, "~> 2.3"},
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:credo, "~> 0.5", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false}
     ]
   end
 
-
   defp package do
     [
-      name: :alexa_request_verifier,
-      files: ["lib", "mix.exs", "README*", "LICENSE*"],
-      maintainers: ["Charlie Graham"],
+      name: :pylon_alexa_request_verifier,
+      files: ["lib", "mix.exs", "priv", "README*", "LICENSE*"],
+      maintainers: ["Josh Ziegler"],
       licenses: ["Apache 2.0"],
-      links: %{"GitHub" => "https://github.com/grahac/alexa_request_verifier"}
+      links: %{"GitHub" => "https://github.com/pylon/alexa_request_verifier"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,16 @@
-%{"con_cache": {:hex, :con_cache, "0.12.0", "2d961aec219aa5a914473873f348f5a6088292dc69d5192a9d25f8a1e13e9905", [:mix], [{:exactor, "~> 2.2.0", [hex: :exactor, optional: false]}]},
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "certifi": {:hex, :certifi, "2.3.1", "d0f424232390bf47d82da8478022301c561cf6445b5b5fb6a84d49a9e76d2639", [:rebar3], [{:parse_trans, "3.2.0", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "con_cache": {:hex, :con_cache, "0.12.0", "2d961aec219aa5a914473873f348f5a6088292dc69d5192a9d25f8a1e13e9905", [:mix], [{:exactor, "~> 2.2.0", [hex: :exactor, optional: false]}]},
+  "credo": {:hex, :credo, "0.9.3", "76fa3e9e497ab282e0cf64b98a624aa11da702854c52c82db1bf24e54ab7c97a", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "exactor": {:hex, :exactor, "2.2.3", "a6972f43bb6160afeb73e1d8ab45ba604cd0ac8b5244c557093f6e92ce582786", [:mix], []},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
+  "parse_trans": {:hex, :parse_trans, "3.2.0", "2adfa4daf80c14dc36f522cf190eb5c4ee3e28008fc6394397c16f62a26258c2", [:rebar3], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.0", "1c01124caa1b4a7af46f2050ff11b267baa3edb441b45dbf243e979cd4c5891b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: false]}]},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], []},
   "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []}}
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+}

--- a/test/alexa_request_verifier_test.exs
+++ b/test/alexa_request_verifier_test.exs
@@ -1,93 +1,141 @@
 defmodule AlexaRequestVerifierTest do
-  use ExUnit.Case
-  doctest AlexaRequestVerifier
+  use ExUnit.Case, async: false
 
-  test "load, verified cert and test caching " do 
-    cert_url = "https://s3.amazonaws.com/echo.api/echo-api-cert-4.pem"
-    conn = %Plug.Conn{}
-    |> Plug.Conn.put_req_header("signaturecertchainurl", cert_url )
-    |> AlexaRequestVerifier.get_validated_cert
-    cert = conn.private[:signing_cert]
-    assert ConCache.get(:cert_signature_cache, cert_url) == cert
-    assert AlexaRequestVerifier.get_validated_cert(conn).private[:signing_cert] == cert
+  import ExUnit.CaptureLog
+
+  alias AlexaRequestVerifier.CertCache
+  alias Plug.Conn
+
+  setup do
+    GenServer.call(CertCache, :purge)
+    :ok
   end
 
-  test "load, bad cert and test no caching " do 
+  test "load, verified cert and test caching " do
+    cert_url = "https://s3.amazonaws.com/echo.api/echo-api-cert-6-ats.pem"
+
+    assert capture_log(fn ->
+             conn =
+               %Conn{}
+               |> Conn.put_req_header("signaturecertchainurl", cert_url)
+               |> AlexaRequestVerifier.populate_cert()
+
+             cert = conn.private[:signing_cert]
+             assert CertCache.get_cert(cert_url) == cert
+             refute conn.private[:alexa_verify_error]
+
+             assert AlexaRequestVerifier.populate_cert(conn).private[
+                      :signing_cert
+                    ] == cert
+           end) =~ ~r/caching url/
+  end
+
+  test "load, bad cert and test no caching " do
     cert_url = "https://s3.amazonaws.com/echo.api/echo-api-cert.pem"
-    conn = %Plug.Conn{}
-    |> Plug.Conn.put_req_header("signaturecertchainurl", cert_url)
-    |> AlexaRequestVerifier.get_validated_cert
-    assert (conn.private[:alexa_verify_error])
-    assert ConCache.get(:cert_signature_cache, cert_url) == nil
 
+    assert capture_log(fn ->
+             conn =
+               %Conn{}
+               |> Conn.put_req_header("signaturecertchainurl", cert_url)
+               |> AlexaRequestVerifier.populate_cert()
 
+             assert conn.private[:alexa_verify_error]
+             assert CertCache.get_cert(cert_url) == nil
+           end) =~ ~r/validation error/
   end
 
-
-
-  test "load bad cache test " do 
+  test "load bad cache test " do
     cert_url = "https://s3.amazonaws.com/echo.api/echo-api-cert.pem"
-    conn = %Plug.Conn{}
-    |> Plug.Conn.put_req_header("signaturecertchainurl", cert_url)
-    |> Plug.Conn.put_req_header("signature", "M4Xq8WmUHjaR4Fgj9HUheoOUkZf4tkc5koBtkBq/nCmh4X6EiimBXWa7p+kHoMx9noTdytGSUREaxYofTne1CzYOW0wxb9x6Jhor6lMwHAr4cY+aR1AEOkWrjsP94bewRr1/CxYNl7kGcj4+QjbEa/7dL19BNmLiufMLZDdRFsZSzlfXpPaAspsoStqVc/qc26tj5R9wtB0sTS4wbFc4eyCPFaCZocq1gmjfR3YQXupuD7J3slrz54SxukNmL/M1CIoZ8lOXjS82XLkKjsrzXdY5ePk8XsEDjNWkFSLbqzBzGBqzWx4M913uDA6gPx5tFKeoP8FgpV+BHKDf3d4gmQ==")
-    |> Plug.Conn.put_private(:raw_body, "foobar" )
-    |> AlexaRequestVerifier.verify_signature
-    assert (conn.private[:alexa_verify_error])
-    assert ConCache.get(:cert_signature_cache, cert_url) == nil
 
+    conn =
+      %Conn{}
+      |> Conn.put_req_header("signaturecertchainurl", cert_url)
+      |> Conn.put_req_header(
+        "signature",
+        ~s(M4Xq8WmUHjaR4Fgj9HUheoOUkZf4tkc5koBtkBq/nCmh4X6EiimBXWa7) <>
+          ~s(p+kHoMx9noTdytGSUREaxYofTne1CzYOW0wxb9x6Jhor6lMwHAr4cY) <>
+          ~s(+aR1AEOkWrjsP94bewRr1/CxYNl7kGcj4+QjbEa/7dL19BNmLiufML) <>
+          ~s(ZDdRFsZSzlfXpPaAspsoStqVc/qc26tj5R9wtB0sTS4wbFc4eyCPFa) <>
+          ~s(CZocq1gmjfR3YQXupuD7J3slrz54SxukNmL/M1CIoZ8lOXjS82XLkK) <>
+          ~s(jsrzXdY5ePk8XsEDjNWkFSLbqzBzGBqzWx4M913uDA6gPx5tFKeo) <>
+          ~s(P8FgpV+BHKDf3d4gmQ==)
+      )
+      |> Conn.put_private(:raw_body, "foobar")
+      |> AlexaRequestVerifier.verify_signature()
 
+    assert conn.private[:alexa_verify_error]
+    assert CertCache.get_cert(cert_url) == nil
   end
 
+  test "load no cert request " do
+    conn =
+      %Conn{}
+      |> AlexaRequestVerifier.populate_cert()
 
-  test "load no cert request " do 
-    conn = %Plug.Conn{}
-    |> AlexaRequestVerifier.get_validated_cert
-    assert String.contains?(conn.private[:alexa_verify_error], "no request parameter")
+    assert String.contains?(
+             conn.private[:alexa_verify_error],
+             "no request parameter"
+           )
   end
 
-
-
-
-
-  test "is_datetime_valid tests " do 
+  test "is_datetime_valid tests " do
     refute AlexaRequestVerifier.is_datetime_valid?(nil)
     refute AlexaRequestVerifier.is_datetime_valid?("")
     refute AlexaRequestVerifier.is_datetime_valid?("2016-03-20T19:03:53Z")
     refute AlexaRequestVerifier.is_datetime_valid?("2017-03-20T19:03:53Z")
-    assert AlexaRequestVerifier.is_datetime_valid?(DateTime.to_iso8601(DateTime.utc_now()))
+
+    assert AlexaRequestVerifier.is_datetime_valid?(
+             NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+           )
   end
 
- test "valid amazonaws cert url tests" do
-   refute AlexaRequestVerifier.is_correct_alexa_url?(nil)
-   refute AlexaRequestVerifier.is_correct_alexa_url?("http://www.alexa.com")
-   refute AlexaRequestVerifier.is_correct_alexa_url?("hello world")
-   refute AlexaRequestVerifier.is_correct_alexa_url?("http://s3.amazonaws.com/echo.api/echo-api-cert.pem")
-   refute AlexaRequestVerifier.is_correct_alexa_url?("https://s4.amazonaws.com/bad_bad.api/echo-api-cert.pem")
-   refute AlexaRequestVerifier.is_correct_alexa_url?("https://s3.amazonaws.com:12345/echo.api/echo-api-cert.pem")
-   refute AlexaRequestVerifier.is_correct_alexa_url?("ftp://s3.amazonaws.com/echo.api/echo-api-cert.pem")
-   assert AlexaRequestVerifier.is_correct_alexa_url?("https://s3.amazonaws.com:443/echo.api/echo-api-cert.pem")
-   assert AlexaRequestVerifier.is_correct_alexa_url?("https://s3.amazonaws.com/echo.api/echo-api-cert.pem")
-   assert AlexaRequestVerifier.is_correct_alexa_url?("https://s3.amazonaws.com/echo.api/echo-api-cert4.pem")
-   assert AlexaRequestVerifier.is_correct_alexa_url?("https://s3.amazonaws.com/echo.api/../echo.api/echo-api-cert.pem")
-   
+  test "valid amazonaws cert url tests" do
+    refute AlexaRequestVerifier.is_correct_alexa_url?(nil)
+    refute AlexaRequestVerifier.is_correct_alexa_url?("http://www.alexa.com")
+    refute AlexaRequestVerifier.is_correct_alexa_url?("hello world")
 
- end
+    refute AlexaRequestVerifier.is_correct_alexa_url?(
+             "http://s3.amazonaws.com/echo.api/echo-api-cert.pem"
+           )
 
+    refute AlexaRequestVerifier.is_correct_alexa_url?(
+             "https://s4.amazonaws.com/bad_bad.api/echo-api-cert.pem"
+           )
 
-  
+    refute AlexaRequestVerifier.is_correct_alexa_url?(
+             "https://s3.amazonaws.com:12345/echo.api/echo-api-cert.pem"
+           )
 
-  
+    refute AlexaRequestVerifier.is_correct_alexa_url?(
+             "ftp://s3.amazonaws.com/echo.api/echo-api-cert.pem"
+           )
 
+    assert AlexaRequestVerifier.is_correct_alexa_url?(
+             "https://s3.amazonaws.com:443/echo.api/echo-api-cert.pem"
+           )
 
+    assert AlexaRequestVerifier.is_correct_alexa_url?(
+             "https://s3.amazonaws.com/echo.api/echo-api-cert.pem"
+           )
 
- test "test_mode disables authentication checking" do
+    assert AlexaRequestVerifier.is_correct_alexa_url?(
+             "https://s3.amazonaws.com/echo.api/echo-api-cert4.pem"
+           )
+
+    assert AlexaRequestVerifier.is_correct_alexa_url?(
+             "https://s3.amazonaws.com/echo.api/../echo.api/echo-api-cert.pem"
+           )
+  end
+
+  test "test_mode disables authentication checking" do
     cert_url = "https://www.foobar.com"
-    conn = %Plug.Conn{}
-    |> Plug.Conn.put_private(:alexa_verify_test_disable, true)
-    |> Plug.Conn.put_req_header("signaturecertchainurl", cert_url)
-    |> AlexaRequestVerifier.call(%{})
+
+    conn =
+      %Conn{}
+      |> Conn.put_private(:alexa_verify_test_disable, true)
+      |> Conn.put_req_header("signaturecertchainurl", cert_url)
+      |> AlexaRequestVerifier.call(%{})
+
     refute conn.private[:alexa_verify_error]
   end
-
-
 end


### PR DESCRIPTION
Feedback welcome—I'm not 100% sure of the caching strategy (keeping the last root cert used in ETS), but I'm doing it that way to hopefully minimize the number of times we'll have to search the whole list of roots since I haven't been able to find anything in Erlang/Elixir that understands the notion of a trusted cert store; since I don't have that, I have to test each root one by one.

With this strategy, the Amazon-laptop round-trip of a first request after a cold start was ~800ms (including calls to other services involved). Not great, but manageable.